### PR TITLE
Switch hash impl to `AHash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +277,17 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "globset"
@@ -616,6 +639,7 @@ dependencies = [
 name = "tera"
 version = "2.0.0"
 dependencies = [
+ "ahash",
  "criterion",
  "indexmap",
  "insta",
@@ -640,6 +664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "walkdir"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +678,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ serde = "1"
 
 # And optional ones
 indexmap = {version = "2", optional = true}
+ahash = "0.8.3"
 
 [features]
 preserve_order = ["dep:indexmap"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+[[disallowed-types]]
+path = "std::collections::HashMap"
+reason = "Use ahash::HashMap instead (AHash is faster)"
+
+[[disallowed-types]]
+path = "std::collections::HashSet"
+reason = "Use ahash::HashSet instead (AHash is faster)"

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -1,6 +1,8 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
+
+use ahash::HashMap;
 
 use crate::utils::{Span, Spanned};
 use crate::value::{Key, Value};

--- a/src/parsing/compiler.rs
+++ b/src/parsing/compiler.rs
@@ -2,7 +2,8 @@
 use crate::parsing::ast::{BinaryOperator, Block, Expression, Node, UnaryOperator};
 use crate::parsing::instructions::{Chunk, Instruction};
 use crate::value::Value;
-use std::collections::HashMap;
+
+use ahash::{HashMap, HashMapExt};
 
 /// We need to handle some pc jumps but we only know to where after we are done processing it
 #[derive(Debug)]

--- a/src/parsing/instructions.rs
+++ b/src/parsing/instructions.rs
@@ -1,6 +1,6 @@
 use crate::utils::Span;
 use crate::value::Value;
-use std::collections::HashMap;
+use ahash::{HashMap, HashMapExt};
 use std::fmt;
 use std::fmt::Formatter;
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1,6 +1,8 @@
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::BTreeMap;
 use std::iter::Peekable;
+
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 
 use crate::errors::{Error, ErrorKind, SyntaxError, TeraResult};
 use crate::parsing::ast::{

--- a/src/template.rs
+++ b/src/template.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ahash::{HashMap, HashMapExt};
 
 use crate::errors::{Error, ErrorKind, TeraResult};
 use crate::parsing::compiler::CompiledMacroDefinition;

--- a/src/tera.rs
+++ b/src/tera.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ahash::{HashMap, HashMapExt};
 
 use crate::errors::{Error, TeraResult};
 use crate::template::{find_parents, Template};

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -1,5 +1,6 @@
-use std::collections::HashMap;
 use std::fmt;
+
+use ahash::{HashMap, HashMapExt};
 
 use crate::parsing::ast::{Expression, MacroDefinition, Node};
 use crate::parsing::parser::Parser;

--- a/src/tests/rendering.rs
+++ b/src/tests/rendering.rs
@@ -1,5 +1,5 @@
+use ahash::{HashMap, HashMapExt};
 use serde::Serialize;
-use std::collections::HashMap;
 
 use crate::tera::Tera;
 use crate::{Context, Value};

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
+use ahash::{HashMap, HashMapExt};
 #[cfg(feature = "preserve_order")]
 use indexmap::IndexMap;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use crate::value::key::Key;
+use ahash::HashMapExt;
 use serde::{ser, Serialize, Serializer};
 
 use crate::value::utils::SerializationFailed;
+use crate::value::key::Key;
 use crate::value::{Map, StringKind, Value};
 
 pub struct ValueSerializer;

--- a/src/vm/for_loop.rs
+++ b/src/vm/for_loop.rs
@@ -1,9 +1,9 @@
 use crate::value::{Key, StringKind};
 use crate::Value;
 
+use ahash::{HashMap, HashMapExt};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
-use std::collections::HashMap;
 use std::sync::Arc;
 
 // TODO: perf improvements, less to_string

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use ahash::{HashMap, HashMapExt};
 
 use serde::Serialize;
 


### PR DESCRIPTION
AHash is about 8-9% faster than SipHash for our usecase (SipHash is the default hashing algorithm used by `std::collections::HashMap`).

In the serialization bench, it is about 20% faster.

Also added clippy lints to prevent introducing `std::collections::HashMap` back into the codebase.

This is in contrast to #13 which uses `hashbrown::HashSet/Map`. `hashbrown` is strictly faster on my Intel CPU.

This PR is for you to compare it yourself against #13 . IMO #13 is better.