### PR TITLE
feat(benches): Add iai benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +294,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
+name = "iai-callgrind"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2679de583a9f5232b45b1f3a31b5e2f739bccfee9b7902488aca8f8c2c5482d1"
+dependencies = [
+ "bincode",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5af66b85e350097b8c0f6329c6347d3323d010443475741c29a1a167f116fb"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cc1093f263249d7c541c53849dac74f4ae756cd31e3cac1a12204efcec68bd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +480,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,7 +621,7 @@ checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -578,6 +643,16 @@ checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
@@ -593,6 +668,7 @@ version = "2.0.0"
 dependencies = [
  "criterion",
  "hashbrown",
+ "iai-callgrind",
  "indexmap",
  "insta",
  "serde",
@@ -703,7 +779,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -725,7 +801,7 @@ checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -935,5 +1011,5 @@ checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.39",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,9 +301,9 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "iai-callgrind"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2679de583a9f5232b45b1f3a31b5e2f739bccfee9b7902488aca8f8c2c5482d1"
+checksum = "b1ab716cc13aa1b829cfc53968f8495f27b98837cddee6f26b965658518e7ffc"
 dependencies = [
  "bincode",
  "iai-callgrind-macros",
@@ -318,10 +324,12 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-runner"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1093f263249d7c541c53849dac74f4ae756cd31e3cac1a12204efcec68bd"
+checksum = "1cf4da4dbfb1167faad0b13db6368e3be11b6fb09fb1d4161672b468841561d4"
 dependencies = [
+ "glob",
+ "regex",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ unicode = ["dep:unic-segment"]
 
 [dev-dependencies]
 criterion = "0.5"
-iai-callgrind = "0.7.1"
+iai-callgrind = "0.8.0"
 insta = { version = "1", features = ["glob"] }
 serde_derive = "1.0.156"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ unicode = ["dep:unic-segment"]
 
 [dev-dependencies]
 criterion = "0.5"
+iai-callgrind = "0.7.1"
 insta = { version = "1", features = ["glob"] }
 serde_derive = "1.0.156"
 
@@ -38,4 +39,16 @@ harness = false
 
 [[bench]]
 name = "templates"
+harness = false
+
+[[bench]]
+name = "iai-value"
+harness = false
+
+[[bench]]
+name = "iai-escape"
+harness = false
+
+[[bench]]
+name = "iai-templates"
 harness = false

--- a/benches/iai-escape.rs
+++ b/benches/iai-escape.rs
@@ -1,0 +1,76 @@
+use std::hint::black_box;
+
+use iai_callgrind::main;
+use iai_callgrind::library_benchmark;
+use iai_callgrind::library_benchmark_group;
+
+use tera::escape_html;
+
+const NO_HTML_SHORT: &str = "A paragraph without HTML characters that need to be escaped.";
+const HTML_SHORT: &str = "Here->An <<example>> of rust codefn foo(u: &u32) -> &u32 {u}";
+
+// taken from https://github.com/djc/askama/blob/master/askama_escape/benches/all.rs
+const NO_HTML_VERY_LONG: &str = r#"
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin scelerisque eu urna in aliquet.
+Phasellus ac nulla a urna sagittis consequat id quis est. Nullam eu ex eget erat accumsan dictum
+ac lobortis urna. Etiam fermentum ut quam at dignissim. Curabitur vestibulum luctus tellus, sit
+amet lobortis augue tempor faucibus. Nullam sed felis eget odio elementum euismod in sit amet massa.
+Vestibulum sagittis purus sit amet eros auctor, sit amet pharetra purus dapibus. Donec ornare metus
+vel dictum porta. Etiam ut nisl nisi. Nullam rutrum porttitor mi. Donec aliquam ac ipsum eget
+hendrerit. Cras faucibus, eros ut pharetra imperdiet, est tellus aliquet felis, eget convallis
+lacus ipsum eget quam. Vivamus orci lorem, maximus ac mi eget, bibendum vulputate massa. In
+vestibulum dui hendrerit, vestibulum lacus sit amet, posuere erat. Vivamus euismod massa diam,
+vulputate euismod lectus vestibulum nec. Donec sit amet massa magna. Nunc ipsum nulla, euismod
+quis lacus at, gravida maximus elit. Duis tristique, nisl nullam.
+    "#;
+
+const HTML_VERY_LONG: &str = r#"
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris consequat tellus sit
+    amet ornare fermentum. Etiam nec erat ante. In at metus a orci mollis scelerisque.
+    Sed eget ultrices turpis, at sollicitudin erat. Integer hendrerit nec magna quis
+    venenatis. Vivamus non dolor hendrerit, vulputate velit sed, varius nunc. Quisque
+    in pharetra mi. Sed ullamcorper nibh malesuada commodo porttitor. Ut scelerisque
+    sodales felis quis dignissim. Morbi aliquam finibus justo, sit amet consectetur
+    mauris efficitur sit amet. Donec posuere turpis felis, eu lacinia magna accumsan
+    quis. Fusce egestas lacus vel fermentum tincidunt. Phasellus a nulla eget lectus
+    placerat commodo at eget nisl. Fusce cursus dui quis purus accumsan auctor.
+    Donec iaculis felis quis metus consectetur porttitor.
+<p>
+    Etiam nibh mi, <b>accumsan</b> quis purus sed, posuere fermentum lorem. In pulvinar porta
+    maximus. Fusce tincidunt lacinia tellus sit amet tincidunt. Aliquam lacus est, pulvinar
+    non metus a, <b>facilisis</b> ultrices quam. Nulla feugiat leo in cursus eleifend. Suspendisse
+    eget nisi ac justo sagittis interdum id a ipsum. Nulla mauris justo, scelerisque ac
+    rutrum vitae, consequat vel ex.
+</p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p></p>
+<p>
+    Sed sollicitudin <b>sem</b> mauris, at rutrum nibh egestas vel. Ut eu nisi tellus. Praesent dignissim
+    orci elementum, mattis turpis eget, maximus ante. Suspendisse luctus eu felis a tempor. Morbi
+    ac risus vitae sem molestie ullamcorper. Curabitur ligula augue, sollicitudin quis maximus vel,
+    facilisis sed nibh. Aenean auctor magna sem, id rutrum metus convallis quis. Nullam non arcu
+    dictum, lobortis erat quis, rhoncus est. Suspendisse venenatis, mi sed venenatis vehicula,
+    tortor dolor egestas lectus, et efficitur turpis odio non augue. Integer velit sapien, dictum
+    non egestas vitae, hendrerit sed quam. Phasellus a nunc eu erat varius imperdiet. Etiam id
+    sollicitudin turpis, vitae molestie orci. Quisque ornare magna quis metus rhoncus commodo.
+    Phasellus non mauris velit.
+</p>
+<p>
+    Etiam dictum tellus ipsum, nec varius quam ornare vel. Cras vehicula diam nec sollicitudin
+    ultricies. Pellentesque rhoncus sagittis nisl id facilisis. Nunc viverra convallis risus ut
+    luctus. Aliquam vestibulum <b>efficitur massa</b>, id tempus nisi posuere a. Aliquam scelerisque
+    elit justo. Nullam a ante felis. Cras vitae lorem eu nisi feugiat hendrerit. Maecenas vitae
+    suscipit leo, lacinia dignissim lacus. Sed eget volutpat mi. In eu bibendum neque. Pellentesque
+    finibus velit a fermentum rhoncus. Maecenas leo purus, eleifend eu lacus a, condimentum sagittis
+    justo.
+</p>"#;
+
+#[library_benchmark]
+#[bench::long_html(HTML_VERY_LONG)]
+#[bench::long_no_html(NO_HTML_VERY_LONG)]
+#[bench::short_html(HTML_SHORT)]
+#[bench::short_no_html(NO_HTML_SHORT)]
+fn bench_escape_html(input: &str) -> String {
+    format!("{}", black_box(escape_html(input)))
+}
+
+library_benchmark_group!(name = escape; benchmarks = bench_escape_html);
+main!(library_benchmark_groups = escape);

--- a/benches/iai-templates.rs
+++ b/benches/iai-templates.rs
@@ -1,0 +1,208 @@
+use std::hint::black_box;
+
+use iai_callgrind::library_benchmark;
+use iai_callgrind::library_benchmark_group;
+use iai_callgrind::main;
+use serde_derive::Serialize;
+
+use tera::{Context, Tera};
+
+#[derive(Serialize)]
+struct DataWrapper {
+    i: usize,
+    v: String,
+}
+
+impl DataWrapper {
+    fn new(i: usize) -> DataWrapper {
+        DataWrapper {
+            i,
+            v: "Meta
+Before we get to the details, two important notes about the ownership system.
+Rust has a focus on safety and speed. It accomplishes these goals through many ‘zero-cost abstractions’, which means that in Rust, abstractions cost as little as possible in order to make them work. The ownership system is a prime example of a zero cost abstraction. All of the analysis we’ll talk about in this guide is done at compile time. You do not pay any run-time cost for any of these features.
+However, this system does have a certain cost: learning curve. Many new users to Rust experience something we like to call ‘fighting with the borrow checker’, where the Rust compiler refuses to compile a program that the author thinks is valid. This often happens because the programmer’s mental model of how ownership should work doesn’t match the actual rules that Rust implements. You probably will experience similar things at first. There is good news, however: more experienced Rust developers report that once they work with the rules of the ownership system for a period of time, they fight the borrow checker less and less.
+With that in mind, let’s learn about borrowing.".into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct BigObject {
+    field_a: DataWrapper,
+    field_b: DataWrapper,
+    field_c: DataWrapper,
+    field_d: DataWrapper,
+    field_e: DataWrapper,
+    field_f: DataWrapper,
+}
+
+impl BigObject {
+    fn new(i: usize) -> BigObject {
+        BigObject {
+            field_a: DataWrapper::new(i),
+            field_b: DataWrapper::new(i),
+            field_c: DataWrapper::new(i),
+            field_d: DataWrapper::new(i),
+            field_e: DataWrapper::new(i),
+            field_f: DataWrapper::new(i),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Team {
+    name: String,
+    score: u8,
+}
+
+static BIG_TABLE_TEMPLATE: &str = "
+<table>
+{% for row in table %}
+<tr>{% for col in row %}<td>{{ col }}</td>{% endfor %}</tr>
+{% endfor %}
+</table>
+";
+
+static TEAMS_TEMPLATE: &str = r#"
+<html>
+  <head>
+    <title>{{ year }}</title>
+  </head>
+  <body>
+    <h1>CSL {{ year }}</h1>
+    <ul>
+    {% for team in teams %}
+      <li class="{% if loop.index0 == 0 %}champion{% endif %}">
+      <b>{{ team.name }}</b>: {{ team.score }}
+      </li>
+    {% endfor %}
+    </ul>
+  </body>
+</html>
+"#;
+
+fn big_context_setup() -> (Tera, Context) {
+    const NUM_OBJECTS: usize = 100;
+    let mut objects = Vec::with_capacity(NUM_OBJECTS);
+    for i in 0..NUM_OBJECTS {
+        objects.push(BigObject::new(i));
+    }
+
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![(
+        "big_loop.html",
+        "
+{%- for object in objects -%}
+{{ object.field_a.i }}
+{%- if object.field_a.i > 2 -%}
+{%- break -%}
+{%- endif -%}
+{%- endfor -%}
+",
+    )])
+    .unwrap();
+    let mut ctx = Context::new();
+    ctx.insert("objects", &objects);
+    let rendering = tera.render("big_loop.html", &ctx).expect("Good render");
+    assert_eq!(&rendering[..], "0123");
+    (tera, ctx)
+}
+
+#[library_benchmark]
+#[bench::big_context(big_context_setup())]
+fn context((tera, ctx): (Tera, Context)) {
+    // cloning as making the context is the bottleneck part
+    tera.render("big_loop.html", &black_box(ctx).clone())
+        .unwrap();
+}
+
+fn big_table_setup() -> (Tera, Context, &'static str) {
+    const RENDER_TARGET: &str = "big-table.html";
+    let length = 100;
+    let mut table = Vec::with_capacity(length);
+    for _ in 0..length {
+        let mut inner = Vec::with_capacity(length);
+        for i in 0..length {
+            inner.push(i);
+        }
+        table.push(inner);
+    }
+
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![(RENDER_TARGET, BIG_TABLE_TEMPLATE)])
+        .unwrap();
+    let mut ctx = Context::new();
+    ctx.insert("table", &table);
+    (tera, ctx, RENDER_TARGET)
+}
+
+fn teams_setup() -> (Tera, Context, &'static str) {
+    const RENDER_TARGET: &str = "teams.html";
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![(RENDER_TARGET, TEAMS_TEMPLATE)])
+        .unwrap();
+    let mut ctx = Context::new();
+    ctx.insert("year", &2015);
+    ctx.insert(
+        "teams",
+        &vec![
+            Team {
+                name: "Jiangsu".into(),
+                score: 43,
+            },
+            Team {
+                name: "Beijing".into(),
+                score: 27,
+            },
+            Team {
+                name: "Guangzhou".into(),
+                score: 22,
+            },
+            Team {
+                name: "Shandong".into(),
+                score: 12,
+            },
+        ],
+    );
+    (tera, ctx, RENDER_TARGET)
+}
+
+fn realistic_setup() -> (Tera, Context, &'static str) {
+    const RENDER_TARGET: &str = "page.html";
+    let items = vec!["Hello world"; 20];
+    let mut tera = Tera::default();
+    tera.add_raw_templates(vec![
+        (
+            "index.html",
+            std::fs::read_to_string("benches/realistic/index.html").unwrap(),
+        ),
+        (
+            "macros.html",
+            std::fs::read_to_string("benches/realistic/macros.html").unwrap(),
+        ),
+        (
+            RENDER_TARGET,
+            std::fs::read_to_string("benches/realistic/page.html").unwrap(),
+        ),
+    ])
+    .unwrap();
+    let mut ctx = Context::new();
+    ctx.insert("base_url", &"https://tera.netlify.app/");
+    ctx.insert("description", &"Some description");
+    ctx.insert("content", &"<a>Some HTML</a>");
+    ctx.insert("title", &"Tera");
+    ctx.insert("items", &items);
+    ctx.insert("show_ad", &true);
+    (tera, ctx, RENDER_TARGET)
+}
+
+#[library_benchmark]
+#[bench::teams(teams_setup())]
+#[bench::big_table(big_table_setup())]
+#[bench::realistic(realistic_setup())]
+fn render((tera, ctx, target): (Tera, Context, &str)) {
+    black_box(tera.render(target, &ctx)).unwrap();
+}
+
+library_benchmark_group!(name = templates; benchmarks = render, context);
+main!(library_benchmark_groups = templates);

--- a/benches/iai-value.rs
+++ b/benches/iai-value.rs
@@ -1,0 +1,36 @@
+use std::hint::black_box;
+use std::path::PathBuf;
+
+use iai_callgrind::library_benchmark;
+use iai_callgrind::library_benchmark_group;
+use iai_callgrind::main;
+use serde::Serialize;
+
+use tera::value::Value;
+
+#[derive(Serialize, Default)]
+struct Page {
+    path: PathBuf,
+    title: String,
+    summary: String,
+    content: String,
+    permalink: String,
+    draft: bool,
+    generate_feed: bool,
+    word_count: usize,
+    reading_time: usize,
+    backlinks: Vec<String>,
+    pages: Vec<Page>,
+}
+
+#[library_benchmark]
+#[bench::page(&Page::default())]
+fn serialize_value<T>(value: &T)
+where
+    T: Serialize + ?Sized,
+{
+    black_box(Value::from_serializable(value));
+}
+
+library_benchmark_group!(name = serialize; benchmarks = serialize_value);
+main!(library_benchmark_groups = serialize);


### PR DESCRIPTION
iai uses valgrind to get perf counters from the cpu making jitter less of an issue. You need to have valgrind installed to run the benchmarks though.

This fixes the jitter in the `escape_html` benchmarks for me, and should give better numbers to perf imporvements (seeing that the current benchmarks are in the mili-micro second range reductions in the instruction count/cache hits is more noticeable.