### PR TITLE
feat: Avoid std::fmt machinery where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,8 @@ dependencies = [
  "iai-callgrind",
  "indexmap",
  "insta",
+ "itoa",
+ "ryu",
  "serde",
  "serde_derive",
  "unic-segment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ serde = "1"
 # Optional deps
 indexmap = { version = "2", optional = true }
 hashbrown = { version = "0.14", optional = true }
-unic-segment = {version = "0.9", optional = true}
-itoa = "1.0.9"
-ryu = "1.0.15"
+unic-segment = { version = "0.9", optional = true }
+itoa = { version = "1.0.9", optional = true }
+ryu = { version = "1.0.15", optional = true }
 
 [features]
 default = []
@@ -21,6 +21,10 @@ ahash = ["hashbrown", "hashbrown/serde"]
 preserve_order = ["dep:indexmap"]
 # If we want Tera to work with graphemes clusters rather than utf-8 characters
 unicode = ["dep:unic-segment"]
+# Improve performance by adding extra dependencies
+fast = ["no-fmt"]
+# Use itoa/ryu to format numbers (instead of std::fmt)
+no-fmt = ["itoa", "ryu"]
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ serde = "1"
 indexmap = { version = "2", optional = true }
 hashbrown = { version = "0.14", optional = true }
 unic-segment = {version = "0.9", optional = true}
+itoa = "1.0.9"
+ryu = "1.0.15"
 
 [features]
 default = []

--- a/src/value/key.rs
+++ b/src/value/key.rs
@@ -39,7 +39,24 @@ impl<'a> Key<'a> {
             Key::Str(b) => Value::String(Arc::from(*b), StringKind::Normal),
         }
     }
+
+    pub(crate) fn format(&self, f: &mut impl std::io::Write) -> std::io::Result<()> {
+        match self {
+            Key::Bool(v) => f.write_all(if *v { b"true" } else { b"false" }),
+            Key::String(v) => f.write_all(v.as_bytes()),
+            Key::Str(v) => f.write_all(v.as_bytes()),
+            Key::U64(v) => {
+                let mut buf = itoa::Buffer::new();
+                f.write_all(buf.format(*v).as_bytes())
+            }
+            Key::I64(v) => {
+                let mut buf = itoa::Buffer::new();
+                f.write_all(buf.format(*v).as_bytes())
+            }
+        }
+    }
 }
+
 impl<'a> PartialEq for Key<'a> {
     fn eq(&self, other: &Self) -> bool {
         if let (Some(a), Some(b)) = (self.as_str(), other.as_str()) {
@@ -77,6 +94,7 @@ impl<'a> Hash for Key<'a> {
         }
     }
 }
+
 impl<'a> fmt::Display for Key<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {

--- a/src/value/key.rs
+++ b/src/value/key.rs
@@ -1,15 +1,11 @@
 use crate::value::StringKind;
 use crate::Value;
-use serde::ser::Impossible;
 use serde::{Serialize, Serializer};
-use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
 use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-
-use crate::value::utils::SerializationFailed;
 
 /// The key of anything looking like a hashmap (struct/hashmaps)
 #[derive(Debug, Clone)]
@@ -45,14 +41,18 @@ impl<'a> Key<'a> {
             Key::Bool(v) => f.write_all(if *v { b"true" } else { b"false" }),
             Key::String(v) => f.write_all(v.as_bytes()),
             Key::Str(v) => f.write_all(v.as_bytes()),
+            #[cfg(feature = "no-fmt")]
             Key::U64(v) => {
                 let mut buf = itoa::Buffer::new();
                 f.write_all(buf.format(*v).as_bytes())
             }
+            #[cfg(feature = "no-fmt")]
             Key::I64(v) => {
                 let mut buf = itoa::Buffer::new();
                 f.write_all(buf.format(*v).as_bytes())
             }
+            #[cfg(not(feature = "no-fmt"))]
+            _ => write!(f, "{self}"),
         }
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -100,24 +100,49 @@ impl Value {
                 f.write_all(b"}")
             }
             Value::F64(v) => {
-                let mut buf = ryu::Buffer::new();
-                f.write_all(buf.format(*v).as_bytes())
+                #[cfg(feature = "no-fmt")]
+                {
+                    let mut buf = ryu::Buffer::new();
+                    f.write_all(buf.format(*v).as_bytes())
+                }
+                #[cfg(not(feature = "no-fmt"))]
+                write!(f, "{v}")
             }
             Value::U64(v) => {
-                let mut buf = itoa::Buffer::new();
-                f.write_all(buf.format(*v).as_bytes())
+                #[cfg(feature = "no-fmt")]
+                {
+                    let mut buf = itoa::Buffer::new();
+                    f.write_all(buf.format(*v).as_bytes())
+                }
+                #[cfg(not(feature = "no-fmt"))]
+                write!(f, "{v}")
             }
             Value::I64(v) => {
-                let mut buf = itoa::Buffer::new();
-                f.write_all(buf.format(*v).as_bytes())
+                #[cfg(feature = "no-fmt")]
+                {
+                    let mut buf = itoa::Buffer::new();
+                    f.write_all(buf.format(*v).as_bytes())
+                }
+                #[cfg(not(feature = "no-fmt"))]
+                write!(f, "{v}")
             }
             Value::U128(v) => {
-                let mut buf = itoa::Buffer::new();
-                f.write_all(buf.format(*v).as_bytes())
+                #[cfg(feature = "no-fmt")]
+                {
+                    let mut buf = itoa::Buffer::new();
+                    f.write_all(buf.format(*v).as_bytes())
+                }
+                #[cfg(not(feature = "no-fmt"))]
+                write!(f, "{v}")
             }
             Value::I128(v) => {
-                let mut buf = itoa::Buffer::new();
-                f.write_all(buf.format(*v).as_bytes())
+                #[cfg(feature = "no-fmt")]
+                {
+                    let mut buf = itoa::Buffer::new();
+                    f.write_all(buf.format(*v).as_bytes())
+                }
+                #[cfg(not(feature = "no-fmt"))]
+                write!(f, "{v}")
             }
         }
     }

--- a/src/vm/interpreter.rs
+++ b/src/vm/interpreter.rs
@@ -167,7 +167,11 @@ impl<'tera> VirtualMachine<'tera> {
                     }
                 }
                 Instruction::WriteText(t) => {
-                    write_to_buffer!(t);
+                    if let Some(captured) = state.capture_buffers.last_mut() {
+                        captured.write_all(t.as_bytes())?;
+                    } else {
+                        output.write_all(t.as_bytes())?;
+                    }
                 }
                 Instruction::WriteTop => {
                     let (top, top_span) = state.stack.pop();
@@ -177,7 +181,11 @@ impl<'tera> VirtualMachine<'tera> {
                             top_span
                         );
                     }
-                    write_to_buffer!(top);
+                    if let Some(captured) = state.capture_buffers.last_mut() {
+                        top.format(captured)?;
+                    } else {
+                        top.format(output)?;
+                    }
                 }
                 Instruction::Set(name) => {
                     // TODO: do we need to keep those spans?


### PR DESCRIPTION
Looks to be an instruction perf win over the board:

```
iai_templates::templates::render teams:teams_setup()
  Instructions:               34396|39255           (-12.3780%) [-1.14127x]
  L1 Hits:                    48685|56277           (-13.4904%) [-1.15594x]
  L2 Hits:                       29|38              (-23.6842%) [-1.31034x]
  RAM Hits:                     344|381             (-9.71129%) [-1.10756x]
  Total read+write:           49058|56696           (-13.4718%) [-1.15569x]
  Estimated Cycles:           60870|69802           (-12.7962%) [-1.14674x]
iai_templates::templates::render big_table:big_table_setup()
  Instructions:             6669990|12080468        (-44.7870%) [-1.81117x]
  L1 Hits:                 10067825|18575012        (-45.7991%) [-1.84499x]
  L2 Hits:                    12260|12282           (-0.17912%) [-1.00179x]
  RAM Hits:                    1979|2008            (-1.44422%) [-1.01465x]
  Total read+write:        10082064|18589302        (-45.7642%) [-1.84380x]
  Estimated Cycles:        10198390|18706702        (-45.4827%) [-1.83428x]
iai_templates::templates::render realistic:realistic_setup()
  Instructions:              187747|206193          (-8.94599%) [-1.09825x]
  L1 Hits:                   260913|289793          (-9.96573%) [-1.11069x]
  L2 Hits:                      510|513             (-0.58480%) [-1.00588x]
  RAM Hits:                     684|706             (-3.11615%) [-1.03216x]
  Total read+write:          262107|291012          (-9.93258%) [-1.11028x]
  Estimated Cycles:          287403|317068          (-9.35604%) [-1.10322x]
iai_templates::templates::context big_context:big_context_setup()
  Instructions:              490359|491400          (-0.21184%) [-1.00212x]
  L1 Hits:                   684141|685723          (-0.23071%) [-1.00231x]
  L2 Hits:                     5288|5333            (-0.84380%) [-1.00851x]
  RAM Hits:                     181|167             (+8.38323%) [+1.08383x]
  Total read+write:          689610|691223          (-0.23335%) [-1.00234x]
  Estimated Cycles:          716916|718233          (-0.18337%) [-1.00184x]
     Running benches/iai-value.rs (target/release/deps/iai_value-452022e514e9078a)
iai_value::serialize::serialize_value page:& Page :: default()
  Instructions:                7859|7876            (-0.21585%) [-1.00216x]
  L1 Hits:                    10762|10781           (-0.17624%) [-1.00177x]
  L2 Hits:                        4|3               (+33.3333%) [+1.33333x]
  RAM Hits:                     136|138             (-1.44928%) [-1.01471x]
  Total read+write:           10902|10922           (-0.18312%) [-1.00183x]
  Estimated Cycles:           15542|15626           (-0.53757%) [-1.00540x]
```